### PR TITLE
Switched from root user inside devcontainer to a default ubuntu user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04
 
+# Install required packages
 RUN \
     apt-get update \
     && apt-get install -y git sudo \
@@ -8,3 +9,8 @@ RUN \
     qt6-base-dev designer-qt6 \
     qt6-charts-dev qt6-serialport-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Grant sudo rights to the default ubuntu user
+RUN usermod -aG sudo ubuntu \
+    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,5 +12,5 @@ RUN \
 
 # Grant sudo rights to the default ubuntu user
 RUN usermod -aG sudo ubuntu \
-    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/ubuntu \
+    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
     && chmod 0440 /etc/sudoers.d/ubuntu

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"name": "u-scope",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"remoteUser": "ubuntu",
+	"updateRemoteUserUID": true,
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -16,21 +17,16 @@
 	}
 
 	"containerEnv": {
-	    "QT_XCB_GL_INTEGRATION": "none"
+		"QT_XCB_GL_INTEGRATION": "none"
 	}
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }


### PR DESCRIPTION
This change prevents annoying root ownership of the new and existing files in a local copy of a repo.