### PR TITLE
Divide configs into reader and dialog configs

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     simulatedreader.h
     universalreader.cpp
     universalreader.h
+    universalreader_dialog.h
     commontypes.hpp
     simulatedreader_dialog.h
     simulatedreader_dialog.cpp

--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -157,20 +157,21 @@ void DataProcessor::stop_data_processing()
     }
 }
 
-void DataProcessor::configure_reader(ReaderId id, std::shared_ptr<UniversalReaderConfig> config)
+void DataProcessor::configure_reader(ReaderId id,
+                                     std::shared_ptr<UniversalReaderDialogConfig> config)
 {
     if (m_senders.contains(id)) {
         // modify reader
     } else {
-        auto config_copy = config->clone();
+        auto reader_config = config->to_reader_config();
 
-        config_copy->update_period_ms = 20;
+        reader_config->update_period_ms = 20;
 
         UniversalReader *reader = nullptr;
 
-        if (std::dynamic_pointer_cast<SimulatedReaderConfig>(config)) {
+        if (std::dynamic_pointer_cast<SimulatedReaderConfig>(reader_config)) {
             reader = new SimulatedReader(
-                    id, this, std::dynamic_pointer_cast<SimulatedReaderConfig>(config_copy));
+                    id, this, std::dynamic_pointer_cast<SimulatedReaderConfig>(reader_config));
         }
 
         if (reader != nullptr) {

--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -169,9 +169,8 @@ void DataProcessor::configure_reader(ReaderId id,
 
         UniversalReader *reader = nullptr;
 
-        if (std::dynamic_pointer_cast<SimulatedReaderConfig>(reader_config)) {
-            reader = new SimulatedReader(
-                    id, this, std::dynamic_pointer_cast<SimulatedReaderConfig>(reader_config));
+        if (auto sim_config = std::dynamic_pointer_cast<SimulatedReaderConfig>(reader_config)) {
+            reader = new SimulatedReader(id, this, sim_config);
         }
 
         if (reader != nullptr) {

--- a/source/dataprocessor.h
+++ b/source/dataprocessor.h
@@ -2,6 +2,7 @@
 
 #include "commontypes.hpp"
 #include "universalreader.h"
+#include "universalreader_dialog.h"
 
 #include <QHash>
 #include <QList>
@@ -180,7 +181,7 @@ public slots:
      * @param id reader id
      * @param config configuration of the reader
      */
-    void configure_reader(ReaderId id, std::shared_ptr<UniversalReaderConfig> config);
+    void configure_reader(ReaderId id, std::shared_ptr<UniversalReaderDialogConfig> config);
 
     /**
      * @brief Remove reader

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -170,27 +170,7 @@ void MainWindow::source_list_context_menu(const QPoint &pos)
             });
         }
 
-        connect(modify_source_action, &QAction::triggered, this, [this, index, reader_id]() {
-            QDialog *dialog = nullptr;
-
-            if (auto config = std::dynamic_pointer_cast<SimulatedReaderConfig>(
-                        this->m_readers_config.value(reader_id))) {
-                dialog = new SimulatedReaderDialog(this, config);
-            }
-
-            if (dialog != nullptr && dialog->exec() == QDialog::Accepted) {
-                ReaderId new_reader_id = get_available_reader_idx();
-
-                auto config = dynamic_cast<SimulatedReaderDialog *>(dialog)->get_config();
-
-                // Should be configured by data processor
-                config->update_period_ms = 30;
-
-                m_readers_config[new_reader_id] = config;
-
-                delete dialog;
-            }
-        });
+        modify_source_action->setEnabled(false);
         connect(delete_source_action, &QAction::triggered, this, [this, index, reader_id]() {
             emit remove_reader(reader_id);
             // TODO: remove correspondence between reader variables and channels

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -79,8 +79,8 @@ void MainWindow::init_data_processor()
             &DataProcessor::stop_data_processing);
 
     // Register Meta Type which will be used in a communication with Data Processor
-    qRegisterMetaType<std::shared_ptr<UniversalReaderConfig>>(
-            "std::shared_ptr<UniversalReaderConfig>");
+    qRegisterMetaType<std::shared_ptr<UniversalReaderDialogConfig>>(
+            "std::shared_ptr<UniversalReaderDialogConfig>");
 
     m_data_processor_thread->start();
 }

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -2,6 +2,7 @@
 
 #include "dataprocessor.h"
 #include "universalreader.h"
+#include "universalreader_dialog.h"
 
 #include <QChart>
 #include <QLineSeries>
@@ -50,7 +51,7 @@ private:
     QChart *m_chart = nullptr; /**< Pointer to the main QChart. */
     QLineSeries *m_series[channels_amount]; /**< Pointer to Chart's series'. */
     QThread *m_data_processor_thread = nullptr; /**< Thread with a running Data Processor. */
-    QMap<ReaderId, std::shared_ptr<UniversalReaderConfig>>
+    QMap<ReaderId, std::shared_ptr<UniversalReaderDialogConfig>>
             m_readers_config; /**< Readers configuration. */
 
     QStandardItemModel *m_source_list_model = nullptr; /**< Source List model. */
@@ -70,7 +71,7 @@ signals:
      * @param id reader id
      * @param config configuration of the reader
      */
-    void configure_reader(ReaderId id, std::shared_ptr<UniversalReaderConfig> config);
+    void configure_reader(ReaderId id, std::shared_ptr<UniversalReaderDialogConfig> config);
 
     /**
      * @brief Remove reader configuration from the Data Processor

--- a/source/simulatedreader_dialog.cpp
+++ b/source/simulatedreader_dialog.cpp
@@ -4,8 +4,31 @@
 
 #include <variant>
 
+std::shared_ptr<UniversalReaderConfig> SimulatedReaderDialogConfig::to_reader_config() const
+{
+    auto config = std::make_shared<SimulatedReaderConfig>();
+    config->variable_id = this->variable_id;
+
+    std::visit(overloads{ [&config](const ConstConfig &const_conf) {
+                             config->form_conf =
+                                     SimulatedReaderConfig::ConstConfig{ .value =
+                                                                                 const_conf.value };
+                             config->sample_rate = 100;
+                         },
+                          [&config](const SinConfig &sin_conf) {
+                              config->form_conf = SimulatedReaderConfig::SinConfig{
+                                  .frequency = sin_conf.frequency,
+                                  .amplitude = sin_conf.amplitude,
+                              };
+                              config->sample_rate = sin_conf.frequency * 25;
+                          } },
+               this->form_conf);
+
+    return config;
+}
+
 SimulatedReaderDialog::SimulatedReaderDialog(QWidget *parent,
-                                             std::shared_ptr<SimulatedReaderConfig> config)
+                                             std::shared_ptr<const SimulatedReaderConfig> config)
     : QDialog{ parent }
     , ui(new Ui::SimulatedReaderDialog)
     , m_config(config)
@@ -17,11 +40,11 @@ SimulatedReaderDialog::SimulatedReaderDialog(QWidget *parent,
 
     if (config != nullptr) {
         std::visit(overloads{
-                           [ui = this->ui](SimulatedReaderConfig::ConstConfig &const_conf) {
+                           [ui = this->ui](const SimulatedReaderConfig::ConstConfig &const_conf) {
                                ui->graphType->setCurrentIndex(TypeIndexes::Constant);
                                ui->constantValue->setValue(const_conf.value);
                            },
-                           [ui = this->ui](SimulatedReaderConfig::SinConfig &sin_conf) {
+                           [ui = this->ui](const SimulatedReaderConfig::SinConfig &sin_conf) {
                                ui->graphType->setCurrentIndex(TypeIndexes::Sinusoid);
                                ui->sinusoidalFrequency->setValue(sin_conf.frequency);
                                ui->sinusoidalAmplitude->setValue(sin_conf.amplitude);
@@ -34,18 +57,16 @@ SimulatedReaderDialog::SimulatedReaderDialog(QWidget *parent,
     ui->configStackedWidget->setCurrentIndex(ui->graphType->currentIndex());
 }
 
-std::shared_ptr<UniversalReaderConfig> SimulatedReaderDialog::get_config()
+std::shared_ptr<UniversalReaderDialogConfig> SimulatedReaderDialog::get_config()
 {
-    auto config = std::make_shared<SimulatedReaderConfig>();
+    auto config = std::make_shared<SimulatedReaderDialogConfig>();
 
     if (ui->graphType->currentIndex() == TypeIndexes::Constant) {
-        config->sample_rate = 100;
-        config->form_conf = SimulatedReaderConfig::ConstConfig{
+        config->form_conf = SimulatedReaderDialogConfig::ConstConfig{
             .value = ui->constantValue->value(),
         };
     } else if (ui->graphType->currentIndex() == TypeIndexes::Sinusoid) {
-        config->sample_rate = ui->sinusoidalFrequency->value() * 25;
-        config->form_conf = SimulatedReaderConfig::SinConfig{
+        config->form_conf = SimulatedReaderDialogConfig::SinConfig{
             .frequency = ui->sinusoidalFrequency->value(),
             .amplitude = ui->sinusoidalAmplitude->value(),
         };

--- a/source/simulatedreader_dialog.h
+++ b/source/simulatedreader_dialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "simulatedreader.h"
+#include "universalreader_dialog.h"
 
 #include <QDialog>
 
@@ -11,6 +12,39 @@ class SimulatedReaderDialog;
 QT_END_NAMESPACE
 
 /**
+ * @brief Configuration for the @ref SimulatedReader.
+ */
+struct SimulatedReaderDialogConfig : UniversalReaderDialogConfig
+{
+    /**
+     * @brief Constant value.
+     */
+    struct ConstConfig
+    {
+        double value; /**< Constant value. */
+    };
+
+    /**
+     * @brief Sinusoidal wave.
+     */
+    struct SinConfig
+    {
+        int32_t frequency; /**< Frequency of the sinusoid. */
+        double amplitude; /**< Amplitude of the sinusoid. */
+    };
+
+    /**
+     * @brief Variants of a simulated form.
+     */
+    using Config = std::variant<ConstConfig, SinConfig>;
+
+    VariableId variable_id; /**< ID of the generated variable. */
+    Config form_conf; /**< Configuration for the specific form. */
+
+    std::shared_ptr<UniversalReaderConfig> to_reader_config() const;
+};
+
+/**
  * @brief Dialog window to configure Simulated Reader
  */
 class SimulatedReaderDialog : public QDialog
@@ -18,10 +52,21 @@ class SimulatedReaderDialog : public QDialog
     Q_OBJECT
 
 public:
+    /**
+     * @brief Constructor of the dialog window.
+     *
+     * @param parent Parent widget.
+     * @param config Pointer to the configuration of the simulated reader.
+     */
     SimulatedReaderDialog(QWidget *parent = nullptr,
-                          std::shared_ptr<SimulatedReaderConfig> config = nullptr);
+                          std::shared_ptr<const SimulatedReaderConfig> config = nullptr);
 
-    std::shared_ptr<UniversalReaderConfig> get_config();
+    /**
+     * @brief Get configuration of the simulated reader.
+     *
+     * @return Pointer to the configuration of the simulated reader.
+     */
+    std::shared_ptr<UniversalReaderDialogConfig> get_config();
 
 private:
     enum TypeIndexes {
@@ -30,7 +75,8 @@ private:
     };
 
     Ui::SimulatedReaderDialog *ui = nullptr; /**< Pointer to the user interface. */
-    std::shared_ptr<SimulatedReaderConfig> m_config = nullptr;
+    std::shared_ptr<const SimulatedReaderConfig> m_config =
+            nullptr; /**< Pointer to the previous configuration of the simulated reader. */
 
 signals:
 };

--- a/source/simulatedreader_dialog.h
+++ b/source/simulatedreader_dialog.h
@@ -41,7 +41,7 @@ struct SimulatedReaderDialogConfig : UniversalReaderDialogConfig
     VariableId variable_id; /**< ID of the generated variable. */
     Config form_conf; /**< Configuration for the specific form. */
 
-    std::shared_ptr<UniversalReaderConfig> to_reader_config() const;
+    std::shared_ptr<UniversalReaderConfig> to_reader_config() const override;
 };
 
 /**

--- a/source/universalreader_dialog.h
+++ b/source/universalreader_dialog.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "commontypes.hpp"
+#include "universalreader.h"
+
+#include <memory>
 
 /**
  * @brief Configuration for the dialog of the @ref UniversalReader.

--- a/source/universalreader_dialog.h
+++ b/source/universalreader_dialog.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "commontypes.hpp"
+
+/**
+ * @brief Configuration for the dialog of the @ref UniversalReader.
+ */
+struct UniversalReaderDialogConfig
+{
+    virtual ~UniversalReaderDialogConfig() = default;
+    /**
+     * @brief Convert into Reader Config
+     *
+     * @return pointer to the copy of the config
+     */
+    virtual std::shared_ptr<UniversalReaderConfig> to_reader_config() const = 0;
+};


### PR DESCRIPTION
Separate config into reader's and dialog's configs. 