### PR TITLE
Clean readers dependencies

### DIFF
--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -37,22 +37,6 @@ DataProcessor::~DataProcessor()
     }
 }
 
-void DataProcessor::add_variables_data(ReaderId reader_id, QMap<VariableId, QList<DataPoint>> &data)
-{
-    if (m_senders.contains(reader_id)) {
-        auto &sender_info = m_senders[reader_id];
-        if (sender_info.buffer_mutex) {
-            QMutexLocker locker(sender_info.buffer_mutex.get());
-
-            for (auto [variable_id, new_data] : data.asKeyValueRange()) {
-                m_in_buffers[reader_id][variable_id].append(std::move(new_data));
-            }
-        }
-    } else {
-        data.clear();
-    }
-}
-
 DataTime DataProcessor::get_timestamp()
 {
     return std::chrono::duration_cast<std::chrono::microseconds>(
@@ -81,34 +65,24 @@ void DataProcessor::process(void)
 {
     QList<GraphData> new_data;
 
-    for (auto [reader_id, sender_info] : m_senders.asKeyValueRange()) {
-        QMap<VariableId, QList<DataPoint>> in_data;
+    DataTime current_time = get_timestamp();
 
-        if (sender_info.buffer_mutex) {
-            QMutexLocker locker(sender_info.buffer_mutex.get());
-            std::swap(in_data, m_in_buffers[reader_id]);
-        }
+    for (auto [reader_id, reader_data] : m_buffers.asKeyValueRange()) {
+        for (auto [variable_id, var_data] : reader_data.asKeyValueRange()) {
+            auto it = m_var_to_channel.constFind(qMakePair(reader_id, variable_id));
 
-        DataTime current_time = get_timestamp();
-
-        for (auto [variable_id, in_var_data] : in_data.asKeyValueRange()) {
-            if (auto it = m_var_to_channel.constFind(qMakePair(reader_id, variable_id));
-                it != m_var_to_channel.constEnd()) {
+            if (it != m_var_to_channel.constEnd()) {
                 QList<QPointF> processed_values;
 
-                m_buffers[reader_id][variable_id].append(std::move(in_var_data));
-
                 auto cut_it = std::lower_bound(
-                        m_buffers[reader_id][variable_id].begin(),
-                        m_buffers[reader_id][variable_id].end(), m_time_width,
+                        var_data.begin(), var_data.end(), m_time_width,
                         [current_time](const DataPoint &point, uint64_t max_distance) {
                             return get_timestamp_diff_us(point.first, current_time) > max_distance;
                         });
 
-                m_buffers[reader_id][variable_id].erase(m_buffers[reader_id][variable_id].begin(),
-                                                        cut_it);
+                var_data.erase(var_data.begin(), cut_it);
 
-                for (auto &val_it : m_buffers[reader_id][variable_id]) {
+                for (auto &val_it : var_data) {
                     const auto val = std::visit([](auto &&arg) { return static_cast<qreal>(arg); },
                                                 val_it.second);
 
@@ -121,6 +95,8 @@ void DataProcessor::process(void)
                 }
 
                 new_data.emplace_back(it.value(), std::move(processed_values));
+            } else {
+                var_data.clear();
             }
         }
     }
@@ -174,11 +150,11 @@ void DataProcessor::configure_reader(ReaderId id,
         UniversalReader *reader = nullptr;
 
         if (auto sim_config = std::dynamic_pointer_cast<SimulatedReaderConfig>(reader_config)) {
-            reader = new SimulatedReader(id, this, sim_config);
+            reader = new SimulatedReader(id, sim_config);
         }
 
         if (reader != nullptr) {
-            DataSenderInfo new_sender{ new QThread(), reader, std::make_shared<QMutex>() };
+            DataSenderInfo new_sender{ new QThread(), reader };
 
             new_sender.sender->moveToThread(new_sender.thread);
 
@@ -189,6 +165,8 @@ void DataProcessor::configure_reader(ReaderId id,
 
             connect(new_sender.sender, &UniversalReader::report_status, this,
                     &DataProcessor::reported_reader_status);
+            connect(new_sender.sender, &UniversalReader::data_ready, this,
+                    &DataProcessor::receive_data);
             connect(this, &DataProcessor::reader_start, new_sender.sender,
                     &UniversalReader::reader_start);
             connect(this, &DataProcessor::reader_stop, new_sender.sender,
@@ -210,7 +188,6 @@ void DataProcessor::remove_reader(ReaderId id)
         sender_info.thread->quit();
 
         m_senders.remove(id);
-        m_in_buffers.remove(id);
         m_buffers.remove(id);
 
         for (auto it = m_var_to_channel.begin(); it != m_var_to_channel.end();) {
@@ -241,5 +218,14 @@ void DataProcessor::set_time_width(uint64_t us)
 {
     if (us > 0) {
         m_time_width = us;
+    }
+}
+
+void DataProcessor::receive_data(ReaderId reader_id, QMap<VariableId, QList<DataPoint>> data)
+{
+    if (m_senders.contains(reader_id)) {
+        for (auto [variable_id, new_data] : data.asKeyValueRange()) {
+            m_buffers[reader_id][variable_id].append(std::move(new_data));
+        }
     }
 }

--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -49,8 +49,8 @@ void DataProcessor::process(void)
 
     UData::Time current_time = UData::get_timestamp();
 
-    for (auto [reader_id, reader_data] : m_buffers.asKeyValueRange()) {
-        for (auto [variable_id, var_data] : reader_data.asKeyValueRange()) {
+    for (auto &&[reader_id, reader_data] : m_buffers.asKeyValueRange()) {
+        for (auto &&[variable_id, var_data] : reader_data.asKeyValueRange()) {
             auto it = m_var_to_channel.constFind(qMakePair(reader_id, variable_id));
 
             if (it != m_var_to_channel.constEnd()) {
@@ -58,7 +58,7 @@ void DataProcessor::process(void)
 
                 auto cut_it = std::lower_bound(
                         var_data.begin(), var_data.end(), m_time_width,
-                        [current_time](const UData::Point &point, uint64_t max_distance) {
+                        [current_time](const UData::Point &point, int64_t max_distance) {
                             return UData::get_timestamp_diff_us(point.first, current_time)
                                     > max_distance;
                         });
@@ -198,7 +198,7 @@ void DataProcessor::assign_channel(QPair<ReaderId, VariableId> variable, Channel
     m_channel_to_var[channel_id] = variable;
 }
 
-void DataProcessor::set_time_width(uint64_t us)
+void DataProcessor::set_time_width(int64_t us)
 {
     if (us > 0) {
         m_time_width = us;
@@ -208,8 +208,10 @@ void DataProcessor::set_time_width(uint64_t us)
 void DataProcessor::receive_data(ReaderId reader_id, QMap<VariableId, QList<UData::Point>> data)
 {
     if (m_senders.contains(reader_id)) {
-        for (auto [variable_id, new_data] : data.asKeyValueRange()) {
-            m_buffers[reader_id][variable_id].append(std::move(new_data));
+        for (auto &&[variable_id, new_data] : data.asKeyValueRange()) {
+            if (m_var_to_channel.contains(qMakePair(reader_id, variable_id))) {
+                m_buffers[reader_id][variable_id].append(std::move(new_data));
+            }
         }
     }
 }

--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -8,7 +8,6 @@
 #include <QMutexLocker>
 #include <QThread>
 #include <QVariant>
-#include <chrono>
 #include <cmath>
 
 DataProcessor::DataProcessor(QPoint left_bottom_corner, QPoint right_top_corner, QObject *parent)
@@ -37,23 +36,6 @@ DataProcessor::~DataProcessor()
     }
 }
 
-DataTime DataProcessor::get_timestamp()
-{
-    return std::chrono::duration_cast<std::chrono::microseconds>(
-                   std::chrono::steady_clock::now().time_since_epoch())
-            .count();
-}
-
-uint64_t DataProcessor::get_timestamp_diff_us(DataTime before, DataTime after)
-{
-    return after - before;
-}
-
-DataTime DataProcessor::timestamp_add_us_roundup(DataTime timestamp, uint64_t us)
-{
-    return timestamp + us;
-}
-
 void DataProcessor::setup(void)
 {
     m_timer = new QTimer(this);
@@ -65,7 +47,7 @@ void DataProcessor::process(void)
 {
     QList<GraphData> new_data;
 
-    DataTime current_time = get_timestamp();
+    UData::Time current_time = UData::get_timestamp();
 
     for (auto [reader_id, reader_data] : m_buffers.asKeyValueRange()) {
         for (auto [variable_id, var_data] : reader_data.asKeyValueRange()) {
@@ -76,8 +58,9 @@ void DataProcessor::process(void)
 
                 auto cut_it = std::lower_bound(
                         var_data.begin(), var_data.end(), m_time_width,
-                        [current_time](const DataPoint &point, uint64_t max_distance) {
-                            return get_timestamp_diff_us(point.first, current_time) > max_distance;
+                        [current_time](const UData::Point &point, uint64_t max_distance) {
+                            return UData::get_timestamp_diff_us(point.first, current_time)
+                                    > max_distance;
                         });
 
                 var_data.erase(var_data.begin(), cut_it);
@@ -87,7 +70,8 @@ void DataProcessor::process(void)
                                                 val_it.second);
 
                     const qreal x_coord = static_cast<qreal>(m_left_bottom_corner.x())
-                            + (m_time_width - get_timestamp_diff_us(val_it.first, current_time))
+                            + (m_time_width
+                               - UData::get_timestamp_diff_us(val_it.first, current_time))
                                     / static_cast<qreal>(m_time_width)
                                     * static_cast<qreal>(m_right_top_corner.x()
                                                          - m_left_bottom_corner.x());
@@ -221,7 +205,7 @@ void DataProcessor::set_time_width(uint64_t us)
     }
 }
 
-void DataProcessor::receive_data(ReaderId reader_id, QMap<VariableId, QList<DataPoint>> data)
+void DataProcessor::receive_data(ReaderId reader_id, QMap<VariableId, QList<UData::Point>> data)
 {
     if (m_senders.contains(reader_id)) {
         for (auto [variable_id, new_data] : data.asKeyValueRange()) {

--- a/source/dataprocessor.h
+++ b/source/dataprocessor.h
@@ -111,34 +111,6 @@ public:
                            QObject *parent = nullptr);
     ~DataProcessor();
 
-    /**
-     * @brief Get current timestamp.
-     *
-     * @note This function uses monotonic clock, so every new call returns a higher value. Except of
-     * the wrapping case.
-     *
-     * @return Current time timestamp.
-     */
-    static DataTime get_timestamp();
-
-    /**
-     * @brief Get the difference between two timestamps.
-     *
-     * @param before Earlier timestamp.
-     * @param after Timestamp after @p before.
-     * @return Time in microseconds between @p before and @p after.
-     */
-    static uint64_t get_timestamp_diff_us(DataTime before, DataTime after);
-
-    /**
-     * @brief Increase timestamp by provided time.
-     *
-     * @param timestamp Original timestamp.
-     * @param us Time in microseconds that should be added to original timestamp.
-     * @return @p timestamp plus @p us round up to the nearest DataTime.
-     */
-    static DataTime timestamp_add_us_roundup(DataTime timestamp, uint64_t us);
-
 public slots:
     /**
      * @brief Initialize DataProcessor.
@@ -201,7 +173,7 @@ public slots:
      * @param reader_id ID of the reader.
      * @param data Data from the reader to be stored in the buffer.
      */
-    void receive_data(ReaderId reader_id, QMap<VariableId, QList<DataPoint>> data);
+    void receive_data(ReaderId reader_id, QMap<VariableId, QList<UData::Point>> data);
 
 signals:
     /**
@@ -249,7 +221,7 @@ private:
             nullptr; /**< Timer to execute processing function and send data to graph Widget. */
     QHash<ReaderId, DataSenderInfo>
             m_senders; /**< Initialized data senders. Sender is used as a key. */
-    QMap<ReaderId, QMap<VariableId, QVector<DataPoint>>>
+    QMap<ReaderId, QMap<VariableId, QVector<UData::Point>>>
             m_buffers; /**< Buffers to store raw data from senders. */
     QHash<QPair<ReaderId, VariableId>, ChannelId>
             m_var_to_channel; /**< Correspondence between variables and channels. */

--- a/source/dataprocessor.h
+++ b/source/dataprocessor.h
@@ -112,16 +112,6 @@ public:
     ~DataProcessor();
 
     /**
-     * @brief Add varibles data into incoming buffer.
-     *
-     * @note Thread-safe if the senders' info is updated when all senders are stopped.
-     *
-     * @param reader_id ID of the sender.
-     * @param data Data to be stored.
-     */
-    void add_variables_data(ReaderId reader_id, QMap<VariableId, QList<DataPoint>> &data);
-
-    /**
      * @brief Get current timestamp.
      *
      * @note This function uses monotonic clock, so every new call returns a higher value. Except of
@@ -205,6 +195,14 @@ public slots:
      */
     void set_time_width(uint64_t us);
 
+    /**
+     * @brief Receive data from the reader and store it in the buffer.
+     *
+     * @param reader_id ID of the reader.
+     * @param data Data from the reader to be stored in the buffer.
+     */
+    void receive_data(ReaderId reader_id, QMap<VariableId, QList<DataPoint>> data);
+
 signals:
     /**
      * @brief Send new data to show in a chart.
@@ -242,8 +240,6 @@ private:
     {
         QThread *thread = nullptr; /**< Pointer to the sender's thread. */
         UniversalReader *sender = nullptr; /**< Pointer to the sender. */
-        std::shared_ptr<QMutex> buffer_mutex =
-                nullptr; /**< Mutex that protects data from this particular sender. */
 
         UniversalReader::Status latest_status =
                 UniversalReader::Uninitialized; /**< Latest known status of the sender. */
@@ -253,9 +249,6 @@ private:
             nullptr; /**< Timer to execute processing function and send data to graph Widget. */
     QHash<ReaderId, DataSenderInfo>
             m_senders; /**< Initialized data senders. Sender is used as a key. */
-    QMap<ReaderId, QMap<VariableId, QList<DataPoint>>>
-            m_in_buffers; /**< Buffers where senders store the data. Sender Mutex is used for a
-                             thread-safety. */
     QMap<ReaderId, QMap<VariableId, QVector<DataPoint>>>
             m_buffers; /**< Buffers to store raw data from senders. */
     QHash<QPair<ReaderId, VariableId>, ChannelId>

--- a/source/dataprocessor.h
+++ b/source/dataprocessor.h
@@ -14,7 +14,6 @@
 #include <QString>
 #include <QThread>
 #include <QTimer>
-#include <QVector>
 
 /**
  * @brief Class to store data of one particular graph.
@@ -165,7 +164,7 @@ public slots:
      *
      * @param us window width in microseconds
      */
-    void set_time_width(uint64_t us);
+    void set_time_width(int64_t us);
 
     /**
      * @brief Receive data from the reader and store it in the buffer.
@@ -203,7 +202,7 @@ signals:
     void reader_stop(ReaderId reader_id);
 
 private:
-    static constexpr uint64_t default_time_width = 1000000; /**< Default window width in us. */
+    static constexpr int64_t default_time_width = 1000000; /**< Default window width in us. */
 
     /**
      * @brief Structure to store information regarding Senders (Readers)
@@ -221,14 +220,14 @@ private:
             nullptr; /**< Timer to execute processing function and send data to graph Widget. */
     QHash<ReaderId, DataSenderInfo>
             m_senders; /**< Initialized data senders. Sender is used as a key. */
-    QMap<ReaderId, QMap<VariableId, QVector<UData::Point>>>
+    QMap<ReaderId, QMap<VariableId, QList<UData::Point>>>
             m_buffers; /**< Buffers to store raw data from senders. */
     QHash<QPair<ReaderId, VariableId>, ChannelId>
             m_var_to_channel; /**< Correspondence between variables and channels. */
     QHash<ChannelId, QPair<ReaderId, VariableId>> m_channel_to_var; /**< Correspondence between
                                                                      channels and variables. */
 
-    uint64_t m_time_width; /**< Window width in us. */
+    int64_t m_time_width; /**< Window width in us. */
     QPoint m_left_bottom_corner; /**< Coordinate of the graph's left bottom corner. */
     QPoint m_right_top_corner; /**< Coordinate of the graph's right top corner. */
 };

--- a/source/include/commontypes.hpp
+++ b/source/include/commontypes.hpp
@@ -2,6 +2,7 @@
 
 #include <QMetaType>
 #include <QPair>
+#include <chrono>
 #include <cstdint>
 #include <variant>
 
@@ -13,11 +14,53 @@ struct overloads : Ts...
 template <class... Ts>
 overloads(Ts...) -> overloads<Ts...>;
 
-using DataVariant =
+namespace UData {
+
+using Variant =
         std::variant<char, int32_t, double>; /**< Data variants provided by universal readers. */
-using DataTime = uint64_t; /**< Timestamp format provided by universal readers. */
-using DataPoint = QPair<DataTime, DataVariant>; /**< Combination of the timestamp and the value
-                                                   provided by universal readers. */
+using Time = int64_t; /**< Timestamp format provided by universal readers. */
+using Point = QPair<Time, Variant>; /**< Combination of the timestamp and the value provided by
+                                       universal readers. */
+
+/**
+ * @brief Get current timestamp.
+ *
+ * @note This function uses monotonic clock, so every new call returns a higher value.
+ *
+ * @return Current time timestamp.
+ */
+inline Time get_timestamp()
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+}
+
+/**
+ * @brief Get the difference between two timestamps.
+ *
+ * @param before Earlier timestamp.
+ * @param after Timestamp after @p before.
+ * @return Time in microseconds between @p before and @p after.
+ */
+inline int64_t get_timestamp_diff_us(Time before, Time after)
+{
+    return after - before;
+}
+
+/**
+ * @brief Increase timestamp by provided time.
+ *
+ * @param timestamp Original timestamp.
+ * @param us Time in microseconds that should be added to original timestamp.
+ * @return @p timestamp plus @p us round up to the nearest Data::Time.
+ */
+inline Time timestamp_add_us_roundup(Time timestamp, int64_t us)
+{
+    return timestamp + us;
+}
+
+} // namespace UData
 
 using ReaderId = uint64_t; /**< ID of the reader. */
 Q_DECLARE_METATYPE(ReaderId)

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -100,7 +100,7 @@ signals:
      *
      * @param us window width in microseconds
      */
-    void set_window_time_width(uint64_t us);
+    void set_window_time_width(int64_t us);
 
 private slots:
     void source_list_context_menu(const QPoint &pos);

--- a/source/readers/CMakeLists.txt
+++ b/source/readers/CMakeLists.txt
@@ -1,10 +1,7 @@
 # Base class for readers
 qt_add_library(universal_reader STATIC)
 
-target_include_directories(
-    universal_reader PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                            ${CMAKE_CURRENT_SOURCE_DIR}/../
-)
+target_include_directories(universal_reader PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(
     universal_reader PRIVATE # cmake-format: sortable

--- a/source/readers/serial/serialreader.cpp
+++ b/source/readers/serial/serialreader.cpp
@@ -2,9 +2,8 @@
 
 #include "dataprocessor.h"
 
-SerialReader::SerialReader(ReaderId id, DataProcessor *processor,
-                           std::shared_ptr<SerialReaderConfig> config)
-    : UniversalReader{ id, processor, config }
+SerialReader::SerialReader(ReaderId id, std::shared_ptr<SerialReaderConfig> config)
+    : UniversalReader{ id, config }
     , m_serial(new QSerialPort(this))
 {
 }

--- a/source/readers/serial/serialreader.cpp
+++ b/source/readers/serial/serialreader.cpp
@@ -1,7 +1,5 @@
 #include "serialreader.h"
 
-#include "dataprocessor.h"
-
 SerialReader::SerialReader(ReaderId id, std::shared_ptr<SerialReaderConfig> config)
     : UniversalReader{ id, config }
     , m_serial(new QSerialPort(this))
@@ -12,10 +10,10 @@ void SerialReader::data_received()
 {
     const QByteArray new_data = m_serial->readAll();
 
-    const auto timestamp = DataProcessor::get_timestamp();
+    const auto timestamp = UData::get_timestamp();
 
     for (auto x : new_data) {
-        m_buffer[0].push_back(DataPoint(timestamp, x));
+        m_buffer[0].push_back(UData::Point(timestamp, x));
     }
 }
 

--- a/source/readers/serial/serialreader.h
+++ b/source/readers/serial/serialreader.h
@@ -36,12 +36,10 @@ public:
     /**
      * @brief Constructor.
      *
-     * @param id id of the reader.
-     * @param processor pointer to the connected Data Processor instance.
+     * @param id ID of the reader.
      * @param config Serial port configuration.
      */
-    explicit SerialReader(ReaderId id, DataProcessor *processor,
-                          std::shared_ptr<SerialReaderConfig> config);
+    explicit SerialReader(ReaderId id, std::shared_ptr<SerialReaderConfig> config);
 
 public slots:
     /**

--- a/source/readers/simulated/simulatedreader.cpp
+++ b/source/readers/simulated/simulatedreader.cpp
@@ -1,7 +1,5 @@
 #include "simulatedreader.h"
 
-#include "dataprocessor.h"
-
 #include <cmath>
 
 SimulatedReader::SimulatedReader(ReaderId id, std::shared_ptr<SimulatedReaderConfig> config)
@@ -24,12 +22,12 @@ void SimulatedReader::setup()
         throw std::range_error("Sample rate must be at least 1");
     }
 
-    m_setup_timestamp = DataProcessor::get_timestamp();
+    m_setup_timestamp = UData::get_timestamp();
 }
 
 void SimulatedReader::start()
 {
-    m_prev_sample_timestamp = DataProcessor::get_timestamp();
+    m_prev_sample_timestamp = UData::get_timestamp();
 }
 
 void SimulatedReader::stop() { }
@@ -37,10 +35,10 @@ void SimulatedReader::stop() { }
 void SimulatedReader::process()
 {
     const auto config = get_config();
-    const auto current_timestamp = DataProcessor::get_timestamp();
+    const auto current_timestamp = UData::get_timestamp();
     const auto sample_interval_us = 1000000UL / config->sample_rate;
 
-    DataTime prev_sample_timestamp = m_prev_sample_timestamp;
+    UData::Time prev_sample_timestamp = m_prev_sample_timestamp;
 
     for (const auto &[variable_id, form_conf] :
          this->get_config()->form_configs.asKeyValueRange()) {
@@ -48,27 +46,25 @@ void SimulatedReader::process()
         prev_sample_timestamp = m_prev_sample_timestamp;
 
         std::visit(overloads{ [&](const SimulatedReaderConfig::ConstConfig &const_conf) {
-                                 for (DataTime t = DataProcessor::timestamp_add_us_roundup(
+                                 for (UData::Time t = UData::timestamp_add_us_roundup(
                                               prev_sample_timestamp, sample_interval_us);
                                       t < current_timestamp;
-                                      t = DataProcessor::timestamp_add_us_roundup(
-                                              t, sample_interval_us)) {
+                                      t = UData::timestamp_add_us_roundup(t, sample_interval_us)) {
                                      m_buffer[variable_id].push_back(
-                                             DataPoint(t, const_conf.value));
+                                             UData::Point(t, const_conf.value));
                                      prev_sample_timestamp = t;
                                  }
                              },
                               [&](const SimulatedReaderConfig::SinConfig &sin_conf) {
-                                  for (DataTime t = DataProcessor::timestamp_add_us_roundup(
+                                  for (UData::Time t = UData::timestamp_add_us_roundup(
                                                prev_sample_timestamp, sample_interval_us);
                                        t < current_timestamp;
-                                       t = DataProcessor::timestamp_add_us_roundup(
-                                               t, sample_interval_us)) {
-                                      const double x = DataProcessor::get_timestamp_diff_us(
+                                       t = UData::timestamp_add_us_roundup(t, sample_interval_us)) {
+                                      const double x = UData::get_timestamp_diff_us(
                                                                this->m_setup_timestamp, t)
                                               * 2 * M_PI * sin_conf.frequency / 1000000;
                                       m_buffer[variable_id].push_back(
-                                              DataPoint(t, sin(x) * sin_conf.amplitude));
+                                              UData::Point(t, sin(x) * sin_conf.amplitude));
                                       prev_sample_timestamp = t;
                                   }
                               } },

--- a/source/readers/simulated/simulatedreader.cpp
+++ b/source/readers/simulated/simulatedreader.cpp
@@ -4,9 +4,8 @@
 
 #include <cmath>
 
-SimulatedReader::SimulatedReader(ReaderId id, DataProcessor *processor,
-                                 std::shared_ptr<SimulatedReaderConfig> config)
-    : UniversalReader{ id, processor, config }
+SimulatedReader::SimulatedReader(ReaderId id, std::shared_ptr<SimulatedReaderConfig> config)
+    : UniversalReader{ id, config }
 {
 }
 

--- a/source/readers/simulated/simulatedreader.h
+++ b/source/readers/simulated/simulatedreader.h
@@ -65,8 +65,8 @@ public:
 public slots:
 
 private:
-    DataTime m_setup_timestamp = 0; /**< Setup timestamp. */
-    DataTime m_prev_sample_timestamp = 0; /**< Timestamp of a previous sample. */
+    UData::Time m_setup_timestamp = 0; /**< Setup timestamp. */
+    UData::Time m_prev_sample_timestamp = 0; /**< Timestamp of a previous sample. */
 
     /**
      * @brief Get the configuration.

--- a/source/readers/simulated/simulatedreader.h
+++ b/source/readers/simulated/simulatedreader.h
@@ -5,8 +5,6 @@
 #include <QHash>
 #include <QObject>
 
-class DataProcessor;
-
 /**
  * @brief Configuration for the @ref SimulatedReader.
  */
@@ -59,12 +57,10 @@ public:
     /**
      * @brief Constructor.
      *
-     * @param id id of the reader.
-     * @param processor Pointer to the connected Data Processor instance.
+     * @param id ID of the reader.
      * @param config Simulated reader configuration.
      */
-    explicit SimulatedReader(ReaderId id, DataProcessor *processor,
-                             std::shared_ptr<SimulatedReaderConfig> config);
+    explicit SimulatedReader(ReaderId id, std::shared_ptr<SimulatedReaderConfig> config);
 
 public slots:
 

--- a/source/readers/universalreader.cpp
+++ b/source/readers/universalreader.cpp
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 
-UniversalReader::UniversalReader(uint64_t id, std::shared_ptr<UniversalReaderConfig> config)
+UniversalReader::UniversalReader(ReaderId id, std::shared_ptr<UniversalReaderConfig> config)
     : QObject{ nullptr }
     , m_id(id)
     , m_config(std::move(config))

--- a/source/readers/universalreader.cpp
+++ b/source/readers/universalreader.cpp
@@ -1,14 +1,10 @@
 #include "universalreader.h"
 
-#include "dataprocessor.h"
-
 #include <QDebug>
 
-UniversalReader::UniversalReader(uint64_t id, DataProcessor *processor,
-                                 std::shared_ptr<UniversalReaderConfig> config)
+UniversalReader::UniversalReader(uint64_t id, std::shared_ptr<UniversalReaderConfig> config)
     : QObject{ nullptr }
     , m_id(id)
-    , m_data_processor(processor)
     , m_config(std::move(config))
 {
 }
@@ -80,7 +76,7 @@ void UniversalReader::reader_process()
         process();
 
         if (!m_buffer.isEmpty()) {
-            m_data_processor->add_variables_data(m_id, m_buffer);
+            emit data_ready(m_id, std::move(m_buffer));
             m_buffer.clear();
         }
     }

--- a/source/readers/universalreader.h
+++ b/source/readers/universalreader.h
@@ -52,7 +52,7 @@ public:
      * @param id ID of the reader.
      * @param config Reader configuration that includes config of the child.
      */
-    explicit UniversalReader(uint64_t id, std::shared_ptr<UniversalReaderConfig> config);
+    explicit UniversalReader(ReaderId id, std::shared_ptr<UniversalReaderConfig> config);
     UniversalReader(const UniversalReader &processor) = delete;
     UniversalReader(UniversalReader &&processor) = delete;
 

--- a/source/readers/universalreader.h
+++ b/source/readers/universalreader.h
@@ -26,8 +26,6 @@ struct UniversalReaderConfig
 
 Q_DECLARE_METATYPE(std::shared_ptr<UniversalReaderConfig>)
 
-class DataProcessor;
-
 /**
  * @brief Class that provides an unified way to create different data readers.
  */
@@ -51,12 +49,10 @@ public:
     /**
      * @brief Constructor.
      *
-     * @param id id of the reader.
-     * @param processor pointer to the connected Data Processor instance.
+     * @param id ID of the reader.
      * @param config Reader configuration that includes config of the child.
      */
-    explicit UniversalReader(uint64_t id, DataProcessor *processor,
-                             std::shared_ptr<UniversalReaderConfig> config);
+    explicit UniversalReader(uint64_t id, std::shared_ptr<UniversalReaderConfig> config);
     UniversalReader(const UniversalReader &processor) = delete;
     UniversalReader(UniversalReader &&processor) = delete;
 
@@ -87,11 +83,12 @@ private slots:
 
 signals:
     void report_status(ReaderId id, Status status); /**< Report reader status change. */
+    void data_ready(ReaderId reader_id,
+                    QMap<VariableId, QList<DataPoint>> data); /**< Send data when it's ready. */
 
 protected:
     ReaderId m_id = 0; /**< ID of the reader. */
     Status m_status = Uninitialized; /**< Status of the reader. */
-    DataProcessor *m_data_processor = nullptr; /**< Pointer to the DataProcessor. */
     std::shared_ptr<UniversalReaderConfig> m_config; /**< Reader configuration */
     QTimer *m_timer = nullptr; /**< Pointer to the timer for the periodical call of the
                                   reader_process maethod. */

--- a/source/readers/universalreader.h
+++ b/source/readers/universalreader.h
@@ -84,7 +84,7 @@ private slots:
 signals:
     void report_status(ReaderId id, Status status); /**< Report reader status change. */
     void data_ready(ReaderId reader_id,
-                    QMap<VariableId, QList<DataPoint>> data); /**< Send data when it's ready. */
+                    QMap<VariableId, QList<UData::Point>> data); /**< Send data when it's ready. */
 
 protected:
     ReaderId m_id = 0; /**< ID of the reader. */
@@ -93,7 +93,7 @@ protected:
     QTimer *m_timer = nullptr; /**< Pointer to the timer for the periodical call of the
                                   reader_process maethod. */
 
-    QMap<VariableId, QList<DataPoint>>
+    QMap<VariableId, QList<UData::Point>>
             m_buffer; /**< Buffer to store received data before it is sent to the data processor. */
 
     virtual void setup() = 0; /**< Initialization of a particular type of the reader. Called


### PR DESCRIPTION
Move time calculations from DataProcessor to get rid of unnecessary readers' dependency.