### PR TITLE
Optimize exchange between data processor and readers

### DIFF
--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -205,13 +205,17 @@ void DataProcessor::set_time_width(int64_t us)
     }
 }
 
-void DataProcessor::receive_data(ReaderId reader_id, QMap<VariableId, QList<UData::Point>> data)
+void DataProcessor::receive_data(ReaderId reader_id, UniversalReaderBufferMap data)
 {
     if (m_senders.contains(reader_id)) {
         for (auto &&[variable_id, new_data] : data.asKeyValueRange()) {
             if (m_var_to_channel.contains(qMakePair(reader_id, variable_id))) {
-                m_buffers[reader_id][variable_id].append(std::move(new_data));
+                m_buffers[reader_id][variable_id].append(
+                        QList<UData::Point>(new_data->begin(), new_data->end()));
             }
         }
+
+        QMetaObject::invokeMethod(m_senders[reader_id].sender, "release_buffer",
+                                  Qt::QueuedConnection, Q_ARG(UniversalReaderBufferMap, data));
     }
 }

--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -16,6 +16,7 @@ DataProcessor::DataProcessor(QPoint left_bottom_corner, QPoint right_top_corner,
     , m_left_bottom_corner(left_bottom_corner)
     , m_right_top_corner(right_top_corner)
 {
+    qRegisterMetaType<UniversalReaderBufferMap>("UniversalReaderBufferMap");
 }
 
 DataProcessor::~DataProcessor()
@@ -210,8 +211,10 @@ void DataProcessor::receive_data(ReaderId reader_id, UniversalReaderBufferMap da
     if (m_senders.contains(reader_id)) {
         for (auto &&[variable_id, new_data] : data.asKeyValueRange()) {
             if (m_var_to_channel.contains(qMakePair(reader_id, variable_id))) {
-                m_buffers[reader_id][variable_id].append(
-                        QList<UData::Point>(new_data->begin(), new_data->end()));
+                auto &destination_buffer = m_buffers[reader_id][variable_id];
+                destination_buffer.reserve(destination_buffer.size() + new_data->size());
+                std::copy(new_data->begin(), new_data->end(),
+                          std::back_inserter(destination_buffer));
             }
         }
 

--- a/source/dataprocessor.h
+++ b/source/dataprocessor.h
@@ -172,7 +172,7 @@ public slots:
      * @param reader_id ID of the reader.
      * @param data Data from the reader to be stored in the buffer.
      */
-    void receive_data(ReaderId reader_id, QMap<VariableId, QList<UData::Point>> data);
+    void receive_data(ReaderId reader_id, UniversalReaderBufferMap data);
 
 signals:
     /**

--- a/source/readers/serial/serialreader.cpp
+++ b/source/readers/serial/serialreader.cpp
@@ -13,7 +13,7 @@ void SerialReader::data_received()
     const auto timestamp = UData::get_timestamp();
 
     for (auto x : new_data) {
-        m_buffer[0].push_back(UData::Point(timestamp, x));
+        store_data(0, UData::Point(timestamp, x));
     }
 }
 

--- a/source/readers/serial/serialreader.cpp
+++ b/source/readers/serial/serialreader.cpp
@@ -32,6 +32,9 @@ void SerialReader::setup()
     m_serial->setFlowControl(get_config()->flow_control);
 
     connect(m_serial, &QSerialPort::readyRead, this, &SerialReader::data_received);
+
+    // Reserve more than enough space for the buffer
+    allocate_buffer_pool(2, (get_config()->baud_rate + 7) / 8);
 }
 
 void SerialReader::start()

--- a/source/readers/simulated/simulatedreader.cpp
+++ b/source/readers/simulated/simulatedreader.cpp
@@ -23,6 +23,8 @@ void SimulatedReader::setup()
     }
 
     m_setup_timestamp = UData::get_timestamp();
+
+    allocate_buffer_pool(config->form_configs.size() * 2, config->sample_rate);
 }
 
 void SimulatedReader::start()
@@ -50,8 +52,7 @@ void SimulatedReader::process()
                                               prev_sample_timestamp, sample_interval_us);
                                       t < current_timestamp;
                                       t = UData::timestamp_add_us_roundup(t, sample_interval_us)) {
-                                     m_buffer[variable_id].push_back(
-                                             UData::Point(t, const_conf.value));
+                                     store_data(variable_id, UData::Point(t, const_conf.value));
                                      prev_sample_timestamp = t;
                                  }
                              },
@@ -63,8 +64,8 @@ void SimulatedReader::process()
                                       const double x = UData::get_timestamp_diff_us(
                                                                this->m_setup_timestamp, t)
                                               * 2 * M_PI * sin_conf.frequency / 1000000;
-                                      m_buffer[variable_id].push_back(
-                                              UData::Point(t, sin(x) * sin_conf.amplitude));
+                                      store_data(variable_id,
+                                                 UData::Point(t, sin(x) * sin_conf.amplitude));
                                       prev_sample_timestamp = t;
                                   }
                               } },

--- a/source/readers/universalreader.cpp
+++ b/source/readers/universalreader.cpp
@@ -65,9 +65,20 @@ void UniversalReader::reader_stop(ReaderId id)
     m_timer->stop();
 
     stop();
-    m_buffer.clear();
+
+    for (auto &&[key, value] : m_buffer_map.asKeyValueRange()) {
+        value->clear();
+    }
 
     set_status(Stopped);
+}
+
+void UniversalReader::release_buffer(UniversalReaderBufferMap buffer_map)
+{
+    for (auto &&[key, buffer] : buffer_map.asKeyValueRange()) {
+        buffer->clear();
+        m_buffer_pool.emplace(std::move(buffer));
+    }
 }
 
 void UniversalReader::reader_process()
@@ -75,9 +86,9 @@ void UniversalReader::reader_process()
     if ((m_status == Running) && (m_timer->isActive())) {
         process();
 
-        if (!m_buffer.isEmpty()) {
-            emit data_ready(m_id, std::move(m_buffer));
-            m_buffer.clear();
+        if (!m_buffer_map.isEmpty()) {
+            emit data_ready(m_id, std::move(m_buffer_map));
+            m_buffer_map.clear();
         }
     }
 }
@@ -88,4 +99,28 @@ void UniversalReader::set_status(Status new_status)
         m_status = new_status;
         emit report_status(m_id, new_status);
     }
+}
+
+void UniversalReader::allocate_buffer_pool(int amount, size_t reserved_size)
+{
+    for (int i = 0; i < amount; i++) {
+        auto new_buffer = std::make_shared<std::vector<UData::Point>>();
+        new_buffer->reserve(reserved_size);
+        m_buffer_pool.emplace(std::move(new_buffer));
+    }
+}
+
+bool UniversalReader::store_data(const VariableId &id, UData::Point &&data)
+{
+    if (!m_buffer_map.contains(id)) {
+        if (m_buffer_pool.empty()) {
+            return false;
+        }
+        auto new_buffer = m_buffer_pool.top();
+        m_buffer_map.insert(id, std::move(new_buffer));
+    }
+
+    m_buffer_map[id]->emplace_back(std::move(data));
+
+    return true;
 }

--- a/source/readers/universalreader.cpp
+++ b/source/readers/universalreader.cpp
@@ -66,9 +66,12 @@ void UniversalReader::reader_stop(ReaderId id)
 
     stop();
 
-    for (auto &&[key, value] : m_buffer_map.asKeyValueRange()) {
-        value->clear();
+    for (auto &&[key, buffer] : m_buffer_map.asKeyValueRange()) {
+        buffer->clear();
+        m_buffer_pool.emplace(std::move(buffer));
     }
+
+    m_buffer_map.clear();
 
     set_status(Stopped);
 }
@@ -116,7 +119,8 @@ bool UniversalReader::store_data(const VariableId &id, UData::Point &&data)
         if (m_buffer_pool.empty()) {
             return false;
         }
-        auto new_buffer = m_buffer_pool.top();
+        auto new_buffer = std::move(m_buffer_pool.top());
+        m_buffer_pool.pop();
         m_buffer_map.insert(id, std::move(new_buffer));
     }
 

--- a/source/readers/universalreader.h
+++ b/source/readers/universalreader.h
@@ -6,8 +6,10 @@
 #include <QMap>
 #include <QMetaType>
 #include <QObject>
+#include <QSet>
 #include <QTimer>
 #include <memory>
+#include <stack>
 
 /**
  * @brief Configuration for the @ref UniversalReader.
@@ -25,6 +27,13 @@ struct UniversalReaderConfig
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<UniversalReaderConfig>)
+
+/**
+ * @brief Type of the buffer that is used to store data from the reader.
+ */
+using UniversalReaderBufferMap = QMap<VariableId, std::shared_ptr<std::vector<UData::Point>>>;
+
+Q_DECLARE_METATYPE(UniversalReaderBufferMap)
 
 /**
  * @brief Class that provides an unified way to create different data readers.
@@ -65,36 +74,56 @@ public slots:
     void reader_setup(); /**< Initialize common part of a reader and call setup method to initialize
                             specific readers. */
     /**
-     * @brief Start the reader with its periodic timer
+     * @brief Start the reader with its periodic timer.
      *
-     * @param id id of the reader
+     * @param id ID of the reader.
      */
     void reader_start(ReaderId id);
     /**
-     * @brief Stop the reader with its periodic timer
+     * @brief Stop the reader with its periodic timer.
      *
-     * @param id id of the reader
+     * @param id ID of the reader.
      */
     void reader_stop(ReaderId id);
+    /**
+     * @brief Return memory buffer to the reader.
+     *
+     * @param buffer Buffer to be released.
+     */
+    void release_buffer(UniversalReaderBufferMap buffer);
 
 private slots:
     void reader_process(); /**< Periodic function that calls process method and sends data to the
                               data processor. Triggered by timer. */
 
 signals:
-    void report_status(ReaderId id, Status status); /**< Report reader status change. */
-    void data_ready(ReaderId reader_id,
-                    QMap<VariableId, QList<UData::Point>> data); /**< Send data when it's ready. */
+    /**
+     * @brief Report reader status change.
+     *
+     * @param id ID of the reader.
+     * @param status New status of the reader.
+     */
+    void report_status(ReaderId id, Status status);
+    /**
+     * @brief Send data to the data processor when it is ready.
+     *
+     * @param reader_id ID of the reader.
+     * @param data Data to be sent to the data processor.
+     */
+    void data_ready(ReaderId reader_id, UniversalReaderBufferMap data);
+
+private:
+    UniversalReaderBufferMap m_buffer_map; /**< Buffer to store received data before it is sent to
+                                              the data processor. */
+    std::stack<std::shared_ptr<std::vector<UData::Point>>>
+            m_buffer_pool; /**< Pool of variable buffers that can be reused. */
 
 protected:
     ReaderId m_id = 0; /**< ID of the reader. */
     Status m_status = Uninitialized; /**< Status of the reader. */
     std::shared_ptr<UniversalReaderConfig> m_config; /**< Reader configuration */
     QTimer *m_timer = nullptr; /**< Pointer to the timer for the periodical call of the
-                                  reader_process maethod. */
-
-    QMap<VariableId, QList<UData::Point>>
-            m_buffer; /**< Buffer to store received data before it is sent to the data processor. */
+                                  reader_process method. */
 
     virtual void setup() = 0; /**< Initialization of a particular type of the reader. Called
                                  from reader_setup method. */
@@ -103,5 +132,24 @@ protected:
     virtual void process() = 0; /**< Prepare data before sending to the data processor. Called
                                    periodically from reader_process method. */
 
-    void set_status(Status new_status); /**< Set new status of the reader. */
+    /**
+     * @brief Set new status of the reader and emit report_status signal if status was changed.
+     *
+     * @param new_status New status of the reader.
+     */
+    void set_status(Status new_status);
+    /**
+     * @brief Allocate pool of buffers to store data from the reader.
+     *
+     * @param amount Number of buffers to allocate.
+     * @param reserved_size Number of points to reserve in each buffer.
+     */
+    void allocate_buffer_pool(int amount, size_t reserved_size);
+    /**
+     * @brief Store one data point in the buffer.
+     *
+     * @param id ID of the variable.
+     * @param data Data point to be stored.
+     */
+    bool store_data(const VariableId &id, UData::Point &&data);
 };


### PR DESCRIPTION
Use preallocated buffers for an exchange between data processor and readers instead of the Qt queue utilization.