### PR TITLE
chore: Reorder mainwindow methods.

### DIFF
--- a/source/ui/mainwindow.cpp
+++ b/source/ui/mainwindow.cpp
@@ -58,6 +58,64 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
+void MainWindow::handle_start_clicked()
+{
+    m_current_mode = ScopeMode::Roll;
+
+    emit switch_continuous_mode(true);
+
+    emit start_data_processing();
+}
+
+void MainWindow::handle_stop_clicked()
+{
+    emit switch_continuous_mode(false);
+
+    emit stop_data_processing();
+
+    m_current_mode = ScopeMode::Stopped;
+}
+
+void MainWindow::channel_selected(int channel_id)
+{
+    if (channel_id < 0 || channel_id >= this->channels_amount) {
+        return;
+    }
+
+    auto id = static_cast<ChannelId>(channel_id);
+
+    m_channelbar_model.select_channel(id);
+
+    if (m_channelbar_model.is_selected(id)) {
+        ui->verticalScale->setEnabled(true);
+        ui->verticalScale->setValue(m_verticalscale_model.qDialValue(id));
+    }
+}
+
+void MainWindow::channel_toggled(int channel_id)
+{
+    if (channel_id < 0 || channel_id >= this->channels_amount) {
+        return;
+    }
+
+    auto id = static_cast<ChannelId>(channel_id);
+
+    // TODO: enable or disable channel readings
+    if (m_channelbar_model.is_enabled(id)) {
+        m_channelbar_model.disable_channel(id);
+
+        emit disable_channel(id);
+
+        if (m_current_mode == ScopeMode::Stopped) {
+            emit force_graph_refresh();
+        }
+    } else {
+        m_channelbar_model.enable_channel(id);
+
+        emit enable_channel(id);
+    }
+}
+
 void MainWindow::init_data_processor()
 {
     m_data_processor = new DataProcessor;
@@ -385,64 +443,6 @@ void MainWindow::source_list_context_menu(const QPoint &pos)
     }
 
     contextMenu.exec(ui->sourceList->viewport()->mapToGlobal(pos));
-}
-
-void MainWindow::handle_start_clicked()
-{
-    m_current_mode = ScopeMode::Roll;
-
-    emit switch_continuous_mode(true);
-
-    emit start_data_processing();
-}
-
-void MainWindow::handle_stop_clicked()
-{
-    emit switch_continuous_mode(false);
-
-    emit stop_data_processing();
-
-    m_current_mode = ScopeMode::Stopped;
-}
-
-void MainWindow::channel_selected(int channel_id)
-{
-    if (channel_id < 0 || channel_id >= this->channels_amount) {
-        return;
-    }
-
-    auto id = static_cast<ChannelId>(channel_id);
-
-    m_channelbar_model.select_channel(id);
-
-    if (m_channelbar_model.is_selected(id)) {
-        ui->verticalScale->setEnabled(true);
-        ui->verticalScale->setValue(m_verticalscale_model.qDialValue(id));
-    }
-}
-
-void MainWindow::channel_toggled(int channel_id)
-{
-    if (channel_id < 0 || channel_id >= this->channels_amount) {
-        return;
-    }
-
-    auto id = static_cast<ChannelId>(channel_id);
-
-    // TODO: enable or disable channel readings
-    if (m_channelbar_model.is_enabled(id)) {
-        m_channelbar_model.disable_channel(id);
-
-        emit disable_channel(id);
-
-        if (m_current_mode == ScopeMode::Stopped) {
-            emit force_graph_refresh();
-        }
-    } else {
-        m_channelbar_model.enable_channel(id);
-
-        emit enable_channel(id);
-    }
 }
 
 namespace {

--- a/source/ui/mainwindow.h
+++ b/source/ui/mainwindow.h
@@ -30,8 +30,140 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
+    /**
+     * @brief Constructor of MainWindow class.
+     */
     MainWindow();
+
+    /**
+     * @brief Destructor of MainWindow class.
+     */
     ~MainWindow();
+
+public slots:
+
+    /**
+     * @brief Handle click on the start button.
+     */
+    void handle_start_clicked();
+
+    /**
+     * @brief Handle click on the stop button.
+     */
+    void handle_stop_clicked();
+
+    /**
+     * @brief Handle selection of the channel in the channel bar.
+     *
+     * @param channel_id ID of the selected channel.
+     */
+    void channel_selected(int channel_id);
+
+    /**
+     * @brief Handle toggling of the channel in the channel bar.
+     *
+     * @param channel_id ID of the toggled channel.
+     */
+    void channel_toggled(int channel_id);
+
+signals:
+
+    /**
+     * @brief Send reader configuration to the Data Processor
+     *
+     * If the reader exists, it changes the config of it.
+     *
+     * @param id reader id
+     * @param config configuration of the reader
+     */
+    void configure_reader(ReaderId id, std::shared_ptr<UniversalReaderDialogConfig> config);
+
+    /**
+     * @brief Remove reader configuration from the Data Processor
+     *
+     * @param id reader id
+     */
+    void remove_reader(ReaderId id);
+
+    /**
+     * @brief Send correspondence between a variable and a channel to the Data Processor
+     *
+     * @param variable uniq identificator of a variable
+     * @param channel_id id of the channel
+     */
+    void assign_channel(QPair<ReaderId, VariableId> variable, ChannelId channel_id);
+
+    /**
+     * @brief Enable channel in the Data Processor
+     *
+     * @param channel_id ID of the channel to be enabled.
+     */
+    void enable_channel(ChannelId channel_id);
+
+    /**
+     * @brief Disable channel in the Data Processor
+     *
+     * @param channel_id ID of the channel to be disable.
+     */
+    void disable_channel(ChannelId channel_id);
+
+    /**
+     * @brief Update vertical scale of a channel in the Data Processor
+     *
+     * @param channel_id ID of the channel to update.
+     * @param scale New vertical scale for the channel.
+     */
+    void update_channel_vertical_scale(ChannelId channel_id, double scale);
+
+    /**
+     * @brief Start data processing in the Data Processor.
+     */
+    void start_data_processing();
+
+    /**
+     * @brief Stop data processing in the Data Processor.
+     */
+    void stop_data_processing();
+
+    /**
+     * @brief Update sliding window width on the overview chart.
+     *
+     * @param window_width_us New width of the sliding window in microseconds.
+     */
+    void window_width_updated(int64_t window_width_us);
+
+    /**
+     * @brief Reset the sliding window on the overview chart.
+     */
+    void sliding_window_reset(UData::Time min_time, UData::Time max_time, int64_t window_width_us);
+
+    /**
+     * @brief Switch between continuous and stopped mode of the chart.
+     *
+     * @param on True to switch to continuous mode, false to switch to stopped mode.
+     */
+    void switch_continuous_mode(bool on);
+
+    /**
+     * @brief Set the horizontal division of the main chart.
+     *
+     * @param div_us Size of one horizontal division in microseconds.
+     */
+    void set_horizontal_div(int64_t div_us);
+
+    /**
+     * @brief Force refresh of the chart data.
+     */
+    void force_graph_refresh();
+
+private slots:
+
+    /**
+     * @brief Show context menu for the source list.
+     *
+     * @param pos Position of the mouse cursor.
+     */
+    void source_list_context_menu(const QPoint &pos);
 
 private:
     static constexpr ReaderId readers_amount = 10; /**< Maximum amount of readers. */
@@ -134,127 +266,4 @@ private:
      * @param config Configuration of the reader.
      */
     void add_reader(const std::shared_ptr<UniversalReaderDialogConfig> &config);
-
-signals:
-    /**
-     * @brief Send reader configuration to the Data Processor
-     *
-     * If the reader exists, it changes the config of it.
-     *
-     * @param id reader id
-     * @param config configuration of the reader
-     */
-    void configure_reader(ReaderId id, std::shared_ptr<UniversalReaderDialogConfig> config);
-
-    /**
-     * @brief Remove reader configuration from the Data Processor
-     *
-     * @param id reader id
-     */
-    void remove_reader(ReaderId id);
-
-    /**
-     * @brief Send correspondence between a variable and a channel to the Data Processor
-     *
-     * @param variable uniq identificator of a variable
-     * @param channel_id id of the channel
-     */
-    void assign_channel(QPair<ReaderId, VariableId> variable, ChannelId channel_id);
-
-    /**
-     * @brief Enable channel in the Data Processor
-     *
-     * @param channel_id ID of the channel to be enabled.
-     */
-    void enable_channel(ChannelId channel_id);
-
-    /**
-     * @brief Disable channel in the Data Processor
-     *
-     * @param channel_id ID of the channel to be disable.
-     */
-    void disable_channel(ChannelId channel_id);
-
-    /**
-     * @brief Update vertical scale of a channel in the Data Processor
-     *
-     * @param channel_id ID of the channel to update.
-     * @param scale New vertical scale for the channel.
-     */
-    void update_channel_vertical_scale(ChannelId channel_id, double scale);
-
-    /**
-     * @brief Start data processing in the Data Processor.
-     */
-    void start_data_processing();
-
-    /**
-     * @brief Stop data processing in the Data Processor.
-     */
-    void stop_data_processing();
-
-    /**
-     * @brief Update sliding window width on the overview chart.
-     *
-     * @param window_width_us New width of the sliding window in microseconds.
-     */
-    void window_width_updated(int64_t window_width_us);
-
-    /**
-     * @brief Reset the sliding window on the overview chart.
-     */
-    void sliding_window_reset(UData::Time min_time, UData::Time max_time, int64_t window_width_us);
-
-    /**
-     * @brief Switch between continuous and stopped mode of the chart.
-     *
-     * @param on True to switch to continuous mode, false to switch to stopped mode.
-     */
-    void switch_continuous_mode(bool on);
-
-    /**
-     * @brief Set the horizontal division of the main chart.
-     *
-     * @param div_us Size of one horizontal division in microseconds.
-     */
-    void set_horizontal_div(int64_t div_us);
-
-    /**
-     * @brief Force refresh of the chart data.
-     */
-    void force_graph_refresh();
-
-private slots:
-    /**
-     * @brief Show context menu for the source list.
-     *
-     * @param pos Position of the mouse cursor.
-     */
-    void source_list_context_menu(const QPoint &pos);
-
-public slots:
-
-    /**
-     * @brief Handle click on the start button.
-     */
-    void handle_start_clicked();
-
-    /**
-     * @brief Handle click on the stop button.
-     */
-    void handle_stop_clicked();
-
-    /**
-     * @brief Handle selection of the channel in the channel bar.
-     *
-     * @param channel_id ID of the selected channel.
-     */
-    void channel_selected(int channel_id);
-
-    /**
-     * @brief Handle toggling of the channel in the channel bar.
-     *
-     * @param channel_id ID of the toggled channel.
-     */
-    void channel_toggled(int channel_id);
 };

--- a/source/ui/mainwindow.h
+++ b/source/ui/mainwindow.h
@@ -38,7 +38,7 @@ public:
     /**
      * @brief Destructor of MainWindow class.
      */
-    ~MainWindow();
+    ~MainWindow() override;
 
 public slots:
 


### PR DESCRIPTION
Reorder methods to keep them in a more generic way.