### PR TITLE
fix: Send relative timestamps in graph data to ensure accuracy.

### DIFF
--- a/source/dataprocessor.cpp
+++ b/source/dataprocessor.cpp
@@ -404,7 +404,7 @@ DataProcessor::prepare_graph_data(int points_limit, std::optional<UData::Time> s
             const auto &[timestamp, raw_val] = *std::prev(left_it);
             const auto val =
                     std::visit([](auto &&arg) { return static_cast<qreal>(arg); }, raw_val) * scale;
-            processed_values.emplace_back(timestamp, val);
+            processed_values.emplace_back(timestamp - start_time_actual, val);
         }
 
         if (std::distance(left_it, right_it) <= points_limit) {
@@ -413,7 +413,7 @@ DataProcessor::prepare_graph_data(int points_limit, std::optional<UData::Time> s
                         std::visit([](auto &&arg) { return static_cast<qreal>(arg); }, raw_val)
                         * scale;
 
-                processed_values.emplace_back(timestamp, val);
+                processed_values.emplace_back(timestamp - start_time_actual, val);
             }
         } else {
             // Divide the range into equal pieces and provide an average value
@@ -446,7 +446,7 @@ DataProcessor::prepare_graph_data(int points_limit, std::optional<UData::Time> s
                     const UData::Time average_time = min_time + (max_time - min_time) / 2;
                     const qreal average_value = sum / amount * scale;
 
-                    processed_values.emplace_back(average_time, average_value);
+                    processed_values.emplace_back(average_time - start_time_actual, average_value);
                 }
             }
         }
@@ -455,7 +455,7 @@ DataProcessor::prepare_graph_data(int points_limit, std::optional<UData::Time> s
             const auto &[timestamp, raw_val] = *right_it;
             const auto val =
                     std::visit([](auto &&arg) { return static_cast<qreal>(arg); }, raw_val) * scale;
-            processed_values.emplace_back(timestamp, val);
+            processed_values.emplace_back(timestamp - start_time_actual, val);
         }
 
         new_data.emplace_back(channel_id, std::move(processed_values));

--- a/source/ui/mainchart_controller.cpp
+++ b/source/ui/mainchart_controller.cpp
@@ -59,7 +59,7 @@ void MainChartController::receive_stored_data(const QList<GraphData> &new_data,
         return;
     }
 
-    m_axis_x->setRange(requested_start_time, requested_end_time);
+    m_axis_x->setRange(0.0, requested_end_time - requested_start_time);
 
     m_graph_min_time = requested_start_time;
     m_graph_max_time = requested_end_time;

--- a/source/ui/mainchart_controller.h
+++ b/source/ui/mainchart_controller.h
@@ -58,6 +58,8 @@ public slots:
     /**
      * @brief Receive requested data from Data Processor and display it on the graph.
      *
+     * Timestamps in the list of data values are relative to the start time.
+     *
      * @param new_data List of new data to be displayed on the graph.
      * @param requested_start_time Start time of the requested data.
      * @param requested_end_time End time of the requested data.

--- a/source/ui/overviewchart_controller.cpp
+++ b/source/ui/overviewchart_controller.cpp
@@ -49,7 +49,7 @@ void OverviewChartController::receive_full_history(const QList<GraphData> &new_d
         return;
     }
 
-    m_axis_x->setRange(min_time, max_time);
+    m_axis_x->setRange(0.0, max_time - min_time);
 
     m_graph_min_time = min_time;
     m_graph_max_time = max_time;

--- a/source/ui/overviewchart_controller.h
+++ b/source/ui/overviewchart_controller.h
@@ -64,6 +64,9 @@ public slots:
     /**
      * @brief Receive full data history from Data Processor.
      *
+     * Timestamps in the list of data history values are relative to the minimum timestamp of the
+     * data history.
+     *
      * @param new_data List of data history values.
      * @param min_time Minimum timestamp of the data history.
      * @param max_time Maximum timestamp of the data history.


### PR DESCRIPTION
This change should prevent accuracy issues with the conversion of int64 to double.